### PR TITLE
Bug-fix-GJMP-29-Song0title-with-next

### DIFF
--- a/src/main/java/org/player/mp3player/controllers/title/SongTitleController.java
+++ b/src/main/java/org/player/mp3player/controllers/title/SongTitleController.java
@@ -7,9 +7,9 @@ import java.util.Objects;
 import java.util.Timer;
 
 public class SongTitleController implements AutoCloseable {
-    private static final int TITLE_LABEL_SIZE = 34;
+    private static final int TITLE_LABEL_SIZE = 30;
     private static final int TIMER_PERIOD = 200;
-    private static final String ONE_ROTATE_SEPARATOR = " ";
+    private static final String ONE_ROTATE_SEPARATOR = "***   ";
     private final Label songTitleLabel;
     private final Timer titleChangeTimer;
     private SongTitleTimerTask updateSongTitleTimerTask;
@@ -27,6 +27,9 @@ public class SongTitleController implements AutoCloseable {
             runSongTitleUpdateTask(currentSongTitle);
 
         } else {
+            if (Objects.nonNull(updateSongTitleTimerTask)) {
+                updateSongTitleTimerTask.cancel();
+            }
             setSongTitle(currentSongTitle);
         }
     }


### PR DESCRIPTION
Modified transition from short title to long title.
Before during using next command wrong song title was shown.

Modifications:
    modified:       src/main/java/org/player/mp3player/controllers/title/SongTitleController.java