### PR TITLE
Bugfix/gjmp 36 bug playlist highlight

### DIFF
--- a/src/main/java/org/player/mp3player/controllers/MainWindow.java
+++ b/src/main/java/org/player/mp3player/controllers/MainWindow.java
@@ -123,6 +123,9 @@ public class MainWindow implements Initializable {
     public void playMedia() {
 
         if (playing) {
+            if (playListWindowController != null) {
+                playListWindowController.highlightPlayed(songNumber);
+            }
             return;
         }
 
@@ -256,4 +259,11 @@ public class MainWindow implements Initializable {
         button.setTooltip(openTooltip);
     }
 
+    public int getSongNumber() {
+        return songNumber;
+    }
+
+    public void setSongNumber(int songNumber) {
+        this.songNumber = songNumber;
+    }
 }

--- a/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
+++ b/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.BorderPane;
 import lombok.AccessLevel;
 import lombok.Setter;
 import org.player.mp3player.controllers.rowselection.StyleChangingRowFactory;
@@ -20,26 +21,33 @@ public class PlayListWindow implements Initializable {
     private String initialPath = "org/player/mp3player/";
 
     @FXML
+    private BorderPane borderPane;
+
+
     private TableView<MusicItem> tableView;
 
     @FXML
     private Button button;
 
-    @FXML
+
     private TableColumn<MusicItem, Integer> idColumn;
-    @FXML
+
     private TableColumn<MusicItem, String> artistColumn;
-    @FXML
+
     private TableColumn<MusicItem, String> titleColumn;
-    @FXML
+
     private TableColumn<MusicItem, String> timeColumn;
     private StyleChangingRowFactory<MusicItem> rowFactory;
+
+    private ResourceBundle resourceBundle;
 
     @Setter(AccessLevel.PUBLIC)
     private MainWindow mainWindowController;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        resourceBundle = resources;
+        initTable();
         setTableViewData();
         setTableViewStyles();
         tableView.setId("tableView");
@@ -51,6 +59,39 @@ public class PlayListWindow implements Initializable {
                 mainWindowController.playMedia();
             }
         });
+
+    }
+
+    private void initTable() {
+        // Create tableview
+        tableView = new TableView<>();
+
+        // Create columns
+        idColumn = new TableColumn<>(resourceBundle.getString("playlist.id"));
+        artistColumn = new TableColumn<>(resourceBundle.getString("playlist.artist"));
+        titleColumn = new TableColumn<>(resourceBundle.getString("playlist.title"));
+        timeColumn = new TableColumn<>(resourceBundle.getString("playlist.time"));
+
+        // Set columns widths
+        idColumn.setMaxWidth(800.0);
+        idColumn.setPrefWidth(25.0);
+
+        artistColumn.setMaxWidth(3500.0);
+        artistColumn.setPrefWidth(110.0);
+
+        timeColumn.setMaxWidth(800.0);
+        titleColumn.setPrefWidth(210.0);
+
+        timeColumn.setMaxWidth(1200.0);
+        timeColumn.setPrefWidth(40.0);
+
+        tableView.getColumns().setAll(idColumn, artistColumn, titleColumn, timeColumn);
+
+        tableView.setColumnResizePolicy(tableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+
+        //Add to main pain of controller borderPane
+        borderPane.setCenter(tableView);
 
     }
 

--- a/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
+++ b/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
@@ -47,7 +47,7 @@ public class PlayListWindow implements Initializable {
         tableView.setOnMouseClicked(event -> {
             if ((event.getClickCount() == 2) && (tableView.getSelectionModel().getSelectedItem() != null)) {
                 mainWindowController.stopMedia();
-                mainWindowController.setSongNumber(tableView.getSelectionModel().getSelectedItem().getId()-1);
+                mainWindowController.setSongNumber(tableView.getSelectionModel().getFocusedIndex());
                 mainWindowController.playMedia();
             }
         });

--- a/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
+++ b/src/main/java/org/player/mp3player/controllers/PlayListWindow.java
@@ -9,12 +9,14 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.BorderPane;
 import lombok.AccessLevel;
 import lombok.Setter;
-import org.player.mp3player.controllers.rowselection.StyleChangingRowFactory;
+import org.player.mp3player.controllers.table.StyleChangingRowFactory;
+import org.player.mp3player.controllers.table.Table;
 import org.player.mp3player.model.Music;
 import org.player.mp3player.model.MusicItem;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 import java.util.ResourceBundle;
 
 public class PlayListWindow implements Initializable {
@@ -24,7 +26,7 @@ public class PlayListWindow implements Initializable {
     private BorderPane borderPane;
 
 
-    private TableView<MusicItem> tableView;
+    private Table<MusicItem> tableView;
 
     @FXML
     private Button button;
@@ -50,7 +52,8 @@ public class PlayListWindow implements Initializable {
         initTable();
         setTableViewData();
         setTableViewStyles();
-        tableView.setId("tableView");
+        setTableViewMethods();
+
 
         tableView.setOnMouseClicked(event -> {
             if ((event.getClickCount() == 2) && (tableView.getSelectionModel().getSelectedItem() != null)) {
@@ -64,7 +67,9 @@ public class PlayListWindow implements Initializable {
 
     private void initTable() {
         // Create tableview
-        tableView = new TableView<>();
+        tableView = new Table<MusicItem>();
+
+        tableView.setId("tableView");
 
         // Create columns
         idColumn = new TableColumn<>(resourceBundle.getString("playlist.id"));
@@ -120,7 +125,7 @@ public class PlayListWindow implements Initializable {
         rowFactory = new StyleChangingRowFactory<>("highlightedRow");
         tableView.setRowFactory(rowFactory);
 
-        tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+//        tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 //        button.disableProperty().bind(Bindings.isEmpty(tableView.getSelectionModel().getSelectedIndices()));
         button.setDisable(true);
     }
@@ -131,7 +136,92 @@ public class PlayListWindow implements Initializable {
 
     public void highlightPlayed(int songPlayed) {
         ObservableList<Integer> rowsToHighlight = FXCollections.observableList(Arrays.asList(songPlayed));
+        rowFactory.getStyledRowIndices().clear();
         rowFactory.getStyledRowIndices().setAll(rowsToHighlight);
+    }
+
+    private void setTableViewMethods(){
+
+        tableView.setOnSort(event -> {
+            System.out.println("-----Set On Sort Start");
+
+            tableView.setHighlightedRows(rowFactory.getStyledRowIndices());
+
+            if (tableView.getHighlightedRows().size() == 0) {
+                tableView.setMusicItemHighlighted(null);
+                System.out.println("-----Set On Sort interrupted");
+                return;
+            }
+
+            tableView.setMusicItemHighlighted((MusicItem) tableView.getItems().get(tableView.getHighlightedRows().get(0)));
+
+            if (tableView.getMusicItemHighlighted() == null){
+                System.out.println("-----Set On Sort interrupted");
+                return;
+            }
+//            showHighlightedRows(tableView.getHighlightedRows());
+//            System.out.println("Table before sort");
+//            System.out.println(printTableItems((ObservableList<MusicItem>)tableView.getItems()));
+
+            System.out.println("-----Set On Sort End");
+        });
+
+        tableView.setAfterSort(() -> {
+            System.out.println("After Sort is working");
+            System.out.println("-----After Sort  start");
+
+            if (tableView.getMusicItemHighlighted() == null){
+                System.out.println("-----After Sort interrupted");
+                return;
+            }
+
+            rowFactory.getStyledRowIndices().clear();
+
+            tableView.getHighlightedRows().add(tableView.getItems().indexOf(tableView.getMusicItemHighlighted()));
+
+            final StyleChangingRowFactory<MusicItem> rowFactoryLocal = new StyleChangingRowFactory<>("highlightedRow");
+            tableView.setRowFactory(rowFactoryLocal);
+
+            rowFactoryLocal.getStyledRowIndices().setAll(tableView.getHighlightedRows());
+
+            tableView.setHighlightedRows(rowFactoryLocal.getStyledRowIndices());
+
+
+//            showHighlightedRows(tableView.getHighlightedRows());
+//
+//            System.out.println("Table after sort");
+//            System.out.println(printTableItems((ObservableList<MusicItem>)tableView.getItems()));
+
+            //Select right current song number
+            mainWindowController.setSongNumber(tableView.getItems().indexOf(tableView.getMusicItemHighlighted()));
+
+            System.out.println("-----After Sort end");
+        });
+
+    }
+
+    private void showHighlightedRows(List<Integer> highlightedRows) {
+        if (highlightedRows.size() == 0) {
+            return;
+        }
+        for (Integer rowNumber :
+                highlightedRows) {
+            MusicItem musicItem = (MusicItem) tableView.getItems().get(rowNumber);
+            System.out.println("Highlighted person: " + musicItem);
+            System.out.println("Highlighted person index: " + tableView.getItems().indexOf(musicItem));
+
+        }
+    }
+
+    public String printTableItems(ObservableList<MusicItem> tableItems) {
+        StringBuilder stringResult = new StringBuilder();
+        for (MusicItem musicItem:
+                tableItems) {
+            stringResult.append("Index :").append(tableItems.indexOf(musicItem)).append(" ")
+                    .append(musicItem.toString()).append("\n");
+        }
+        stringResult.append("----------------------");
+        return stringResult.toString();
     }
 
 }

--- a/src/main/java/org/player/mp3player/controllers/rowselection/StyleChangingRowFactory.java
+++ b/src/main/java/org/player/mp3player/controllers/rowselection/StyleChangingRowFactory.java
@@ -110,15 +110,15 @@ public class StyleChangingRowFactory<T> implements
             }
         });
 
-
-        row.setOnMouseClicked(event -> {
-            if (event.getClickCount() == 2 && (!row.isEmpty())) {
-                T rowData = row.getItem();
-                MusicItem musicItem = (MusicItem)rowData;
+//        row.setOnMouseClicked(event -> {
+//            if (event.getClickCount() == 2 && (!row.isEmpty())) {
+//                T rowData = row.getItem();
+//                MusicItem musicItem = (MusicItem)rowData;
 //                System.out.println(musicItem.getId());
-                getStyledRowIndices().setAll(musicItem.getId()-1);
-            }
-        });
+//                getStyledRowIndices().setAll(musicItem.getId()-1);
+//            }
+//        });
+
         
         styledRowIndices.addListener(new ListChangeListener<Integer>() {
             @Override

--- a/src/main/java/org/player/mp3player/controllers/table/AfterSort.java
+++ b/src/main/java/org/player/mp3player/controllers/table/AfterSort.java
@@ -1,0 +1,6 @@
+package org.player.mp3player.controllers.table;
+
+public interface AfterSort {
+
+    public void afterSortAction();
+}

--- a/src/main/java/org/player/mp3player/controllers/table/StyleChangingRowFactory.java
+++ b/src/main/java/org/player/mp3player/controllers/table/StyleChangingRowFactory.java
@@ -1,4 +1,4 @@
-package org.player.mp3player.controllers.rowselection;
+package org.player.mp3player.controllers.table;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;

--- a/src/main/java/org/player/mp3player/controllers/table/Table.java
+++ b/src/main/java/org/player/mp3player/controllers/table/Table.java
@@ -1,0 +1,46 @@
+package org.player.mp3player.controllers.table;
+
+import javafx.scene.control.TableView;
+import org.player.mp3player.model.MusicItem;
+
+import java.util.List;
+
+public class Table<S> extends TableView {
+
+    private StyleChangingRowFactory<MusicItem> rowFactory;
+
+    private List<Integer> HighlightedRows;
+    private MusicItem musicItemHighlighted;
+
+    private AfterSort afterSort;
+
+
+    @Override
+    public void sort() {
+        super.sort();
+        afterSort.afterSortAction();
+    }
+
+    public List<Integer> getHighlightedRows() {
+        return HighlightedRows;
+    }
+
+    public void setHighlightedRows(List<Integer> highlightedRows) {
+        HighlightedRows = highlightedRows;
+    }
+
+    public MusicItem getMusicItemHighlighted() {
+        return musicItemHighlighted;
+    }
+
+    public void setMusicItemHighlighted(MusicItem personHighlighted) {
+        this.musicItemHighlighted = personHighlighted;
+    }
+
+    public void setAfterSort(AfterSort afterSort) {
+        this.afterSort = afterSort;
+    }
+
+
+}
+

--- a/src/main/resources/org/player/mp3player/fxml/PlayListWindow.fxml
+++ b/src/main/resources/org/player/mp3player/fxml/PlayListWindow.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.BorderPane?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="160.0" prefWidth="400.0" style="-fx-background-color: grey;" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.player.mp3player.controllers.PlayListWindow">
+<BorderPane fx:id="borderPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="160.0" prefWidth="400.0" style="-fx-background-color: grey;" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.player.mp3player.controllers.PlayListWindow">
    <bottom>
       <ToolBar prefHeight="40.0" prefWidth="200.0" style="-fx-background-color: grey;" BorderPane.alignment="CENTER">
         <items>


### PR DESCRIPTION
Bug fix GJMP-36: Correct bug in playlist highlight after sort
Description of modifications.
- Commit: 3
Currently played song remains selected after sort.
Previously there was the bug that this was not working.
- Commit: 2   
Creation of TableView is now being done from code not fxml.
Table in fxml is left only for reference only.
This is prerequisite to be able to override TableView methods in next commits.
- Commit: 1    
Double click in playlist now plays right song and highlight selected song.
It was not working previously when playlist was sorted by different column than Id.
Now it is working


